### PR TITLE
fixed value="data" not being shown for inputs

### DIFF
--- a/src/components/TextField.js
+++ b/src/components/TextField.js
@@ -38,7 +38,7 @@ class TextField extends React.Component {
   componentWillReceiveProps(nextProps) {
     // update innerValue when new value is received to handle programmatic
     // changes to input box
-    if ('value' in nextProps) this.setState({ innerValue: nextProps.value });
+    if ('value' in nextProps && nextProps.value !== this.state.value) this.setState({ innerValue: nextProps.value });
   }
 
   onBlur(ev) {
@@ -159,6 +159,7 @@ class TextField extends React.Component {
         <Tag 
           {...attributes} 
           id={id}
+          value={this.state.innerValue}
           className={classes} 
           ref={el => { this.inputElRef = el; }}
           placeholder={hint}


### PR DESCRIPTION
having an ``` <Input label="Name" type="text" name="name" id="name" onChange={this.handleChange.bind(this)} value={this.props.user.name} /> ``` will show an active input but no value inside the input even though there is a value