### PR TITLE
Remove onClick callback call in handleClick

### DIFF
--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -21,10 +21,6 @@ class Button extends React.Component {
         time: Date.now()
       };
       this.setState({ cursorPos: cursorPos });
-      // do the passed in callback:
-      if (this.props.onClick) {
-      this.props.onClick(e);
-      }
       e.stopPropagation();
     }
   }


### PR DESCRIPTION
With the onClick callback call in handleClick the callback get's triggered twice when the button is clicked: once once for pressed button and second when releasing.