### PR TITLE
Move react-scripts from dependencies to devDependencies

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,6 @@
 Material Design for Bootstrap
 
-Version: MDB React 4.6.1
+Version: MDB React 4.6.2
 
 Documentation:
 https://mdbootstrap.com/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdbreact",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "author": "MDBootstrap",
   "repository": "https://git.mdbootstrap.com/mdb/react/re-pro",
   "main": "dist/mdbreact.js",
@@ -27,7 +27,6 @@
     "react-numeric-input": "^2.2.3",
     "react-popper": "^0.7.5",
     "react-router-dom": "^4.2.0",
-    "react-scripts": "1.0.11",
     "react-toastify": "^3.2.2"
   },
   "scripts": {
@@ -55,6 +54,7 @@
     "node-sass": "^4.7.2",
     "react-chartjs-2": "^2.7.0",
     "react-image-lightbox": "^4.6.0",
+    "react-scripts": "1.0.11",
     "salad-ui.chart": "^1.1.55",
     "sass-loader": "^6.0.6",
     "style-loader": "^0.18.2",


### PR DESCRIPTION
We need to move react-scripts to devDependencies because otherwise, when users include `mdbreact` as a dependency and do an `npm install`, it also installs `react-scripts` which increases the node_modules size by ~300MB.

It is possible that `react-scripts` can be removed completely, I don't see it being used anywhere, but since there are no tests, I thought it was safer to just move for now.

Closes #44