### PR TITLE
Don't remove class modal-open from body

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -13,10 +13,6 @@ class Modal extends Component {
     document.body.classList.add("modal-open");
   };
 
-  componentWillUnmount = () => {
-    document.body.classList.remove("modal-open");
-  };
-
   componentDidUpdate = (prevProps, prevState) => {
     if (prevState.isOpen !== this.props.isOpen) {
       this.setState({ isOpen: this.props.isOpen });


### PR DESCRIPTION
Don't remove class modal-open from the body, is not necessary and there is a bug with too many modals.. 