### PR TITLE
Fix sorting of table row field components

### DIFF
--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -119,7 +119,12 @@ class DataTable extends Component {
       this.checkFieldValue(b, field)
     ];
 
-    return direction === "desc" ? aField < bField : aField > bField;
+    let comp = aField > bField ? -1 : 1;
+    if (direction === "desc") {
+      comp *= -1
+    }
+
+    return comp;
   };
 
   handleSort = (field, sort) => {


### PR DESCRIPTION
As of v4.15.0, sortRows enabled fields containing components to become searchable and sortable. However, since a small detail was probably missed, the sorting would not work. Here is a simple fix of that.