### PR TITLE
Bug fix for DataTable search box. The whole page was breaking when en…

### DIFF
--- a/src/components/DataTable/DataTable.js
+++ b/src/components/DataTable/DataTable.js
@@ -192,12 +192,19 @@ class DataTable extends Component {
                   }
                 }
 
-                if (
-                  stringValue
-                    .toLowerCase()
-                    .match(this.state.search.toLowerCase())
-                )
-                  return true;
+                var search = this.state.search;
+
+                try {
+                  if (
+                    stringValue
+                      .toLowerCase()
+                      .match(search.toLowerCase())
+                  )
+                    return true;
+                }
+                catch {
+                  this.state.search = search.substring(0, search.length - 1);
+                }
               }
             }
           }


### PR DESCRIPTION
Bug fix for DataTable search box.
The whole page was breaking when entering RegEx special characters into the search box (e.g. +, *, \ etc.).

If you find a better way to solve this bug, please, fix that way.