### PR TITLE
added tag support to Alerts.

### DIFF
--- a/src/components/Alert/Alert.d.ts
+++ b/src/components/Alert/Alert.d.ts
@@ -5,6 +5,7 @@ declare const MDBAlert: React.FunctionComponent<{
     className?: string;
     children?: React.ReactNode;
     dismiss?: boolean;
+    tag?: string;
     onClose?: () => void;
     onClosed?: () => void;
 }>;

--- a/src/components/Alert/Alert.js
+++ b/src/components/Alert/Alert.js
@@ -19,7 +19,7 @@ const Alert = props => {
     props.onClosed && props.onClosed();
   };
 
-  const { className, color, children, dismiss } = props;
+  const { className, tag: Tag, color, children, dismiss } = props;
 
   const alertClasses = classNames("alert", color && `alert-${color}`, className);
 
@@ -34,19 +34,19 @@ const Alert = props => {
         onExit={node => handleOnExit(node)}
         onExited={node => handleOnExited(node)}
       >
-        <div data-test="alert" className={alertClasses} role="alert">
+        <Tag data-test="alert" className={alertClasses} role="alert">
           {children}
           <button onClick={closeAlert} type="button" className="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>
           </button>
-        </div>
+        </Tag>
       </Transition>
     );
   } else {
     alertComponent = (
-      <div data-test="alert" className={alertClasses} role="alert">
+      <Tag data-test="alert" className={alertClasses} role="alert">
         {children}
-      </div>
+      </Tag>
     );
   }
 
@@ -54,14 +54,16 @@ const Alert = props => {
 };
 
 Alert.defaultProps = {
-  color: "primary"
+  color: "primary",
+  tag: "div"
 };
 
 Alert.propTypes = {
   className: PropTypes.string,
   color: PropTypes.oneOf(["primary", "secondary", "success", "danger", "warning", "info", "light", "dark"]),
   onClose: PropTypes.func,
-  onClosed: PropTypes.func
+  onClosed: PropTypes.func,
+  tag: PropTypes.string,
 };
 
 export default Alert;


### PR DESCRIPTION
Hello, I have asked here:
https://mdbootstrap.com/support/react/please-add-tag-support-to-react-alerts-https-mdbootstrap-com-docs-react-components-alerts-just-like-in-mdcard-components/

for you to add support for tags in this component:
https://mdbootstrap.com/docs/react/components/alerts/

and I went ahead and added it myself and made a pull request.

I simpley copied the way tags were implemented here:
https://github.com/vasilevich/React-Bootstrap-with-Material-Design/blob/master/src/components/Card/Card.js

and here:
https://github.com/vasilevich/React-Bootstrap-with-Material-Design/blob/master/src/components/Card/Card.d.ts

into the following files respectively:

https://github.com/vasilevich/React-Bootstrap-with-Material-Design/blob/master/src/components/Alert/Alert.js

https://github.com/vasilevich/React-Bootstrap-with-Material-Design/blob/master/src/components/Alert/Alert.d.ts

please consider my pull request

Thank you!
