### PR TITLE
Only add modal-open class when showModal true

### DIFF
--- a/src/components/Modal/Modal.js
+++ b/src/components/Modal/Modal.js
@@ -14,7 +14,9 @@ class Modal extends Component {
   modalContent = React.createRef();
 
   componentDidMount = () => {
-    document.body.classList.add('modal-open');
+    if(this.props.showModal) {
+      document.body.classList.add('modal-open'); 
+    }
   };
 
   componentWillUnmount = () => {


### PR DESCRIPTION
There is a bug that the "modal-open" class is added to the body tag even when the modal is not yet shown (but component gets mounted).
Checking for showModal === true should fix it.