### PR TITLE
fix sort Icon on DataTable when asc or desc

### DIFF
--- a/dist/scss/addons/_datatables.scss
+++ b/dist/scss/addons/_datatables.scss
@@ -118,7 +118,6 @@ table.dataTable thead {
       position: absolute;
       bottom: .9em;
       display: block;
-      opacity: .3;
     }
   }
   .sorting:before, .sorting_asc:before, .sorting_desc:before, .sorting_asc_disabled:before, .sorting_desc_disabled:before , .sorting_asc > .fa-sort {

--- a/dist/scss/addons/_datatables.scss
+++ b/dist/scss/addons/_datatables.scss
@@ -121,14 +121,14 @@ table.dataTable thead {
       opacity: .3;
     }
   }
-  .sorting:before, .sorting_asc:before, .sorting_desc:before, .sorting_asc_disabled:before, .sorting_desc_disabled:before {
+  .sorting:before, .sorting_asc:before, .sorting_desc:before, .sorting_asc_disabled:before, .sorting_desc_disabled:before , .sorting_asc > .fa-sort {
     right: 1em;
     font-family: "Font Awesome\ 5 Free", sans-serif;
     font-size: 1rem;
     font-weight: 900;
     content: "\f0de";
   }
-  .sorting:after, .sorting_asc:after, .sorting_desc:after, .sorting_asc_disabled:after, .sorting_desc_disabled:after {
+  .sorting:after, .sorting_asc:after, .sorting_desc:after, .sorting_asc_disabled:after, .sorting_desc_disabled:after , .sorting_desc > .fa-sort {
     right: 16px;
     font-family: "Font Awesome\ 5 Free", sans-serif;
     font-size: 1rem;


### PR DESCRIPTION
we don't need opacity because opacity removed black color asc/desc state and no difference between asc and desc sort
